### PR TITLE
sync: zig-dev fix, plus --rebase

### DIFF
--- a/src/zek.zig
+++ b/src/zek.zig
@@ -1399,6 +1399,7 @@ pub const UserInterface = struct {
         _ = try self.shell([_][]const u8{
             "git",
             "pull",
+            "--rebase",
         });
         _ = try self.shell([_][]const u8{
             "git",

--- a/src/zek.zig
+++ b/src/zek.zig
@@ -1304,8 +1304,7 @@ pub const UserInterface = struct {
     }
     const Errors = error{ShellFail};
     fn shell(self: *Self, comptime args: anytype) !u32 {
-        var process = try std.ChildProcess.init(&args, self.allocator);
-        defer process.deinit();
+        var process = std.ChildProcess.init(&args, self.allocator);
         const result = try process.spawnAndWait();
         switch (result) {
             Term.Exited => |n| return n,


### PR DESCRIPTION
Hi @drcode 

I came across your project the other day while I was looking for CLI programs which used a philosophy such as Roam.  Didn't take me long to find yours, and it looks like something I would definitely use!

I happen to be running the zig development version, where there's been some recent changes to stdlib regarding `std.ChildProcess.init()` -- you'll find a fix for that in this PR.

Alongside that, is a separate commit to suggest adding `--rebase` to `git pull` when the `sync` command is being used.