### PR TITLE
Resetting the terminal before exit

### DIFF
--- a/src/zek.zig
+++ b/src/zek.zig
@@ -1728,4 +1728,7 @@ pub fn main() !void {
     var userInterface = try UserInterface.init(gpa.allocator());
     defer userInterface.deinit();
     try userInterface.eventLoop(false);
+    if (builtin.os.tag != .windows) {
+        try std.io.getStdOut().writer().print("\x1b[0m", .{});
+    }
 }


### PR DESCRIPTION
Hi @drcode

I'm happy that I've stumbled upon this project.

I personally find quite annoying that a program changes the terminal state after it's execution.
With this small change, as long as `zek` doesn't crash, the terminal should be reset right before it exits.